### PR TITLE
Scrolled grid content under navigation bar

### DIFF
--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -6,22 +6,26 @@ import {SharedElementAndroid, NavigationBar, SearchBarIOS} from 'navigation-reac
 const Colors = ({colors, children}) => (
   <NavigationContext.Consumer>
     {({stateNavigator}) => (
-      <View style={styles.colors}>
-        {colors.map(color => (
-          <TouchableHighlight
-            key={color}
-            style={styles.color}
-            underlayColor={color}                
-            onPress={() => {
-              stateNavigator.navigate('detail', {color});
-            }}>
-            <SharedElementAndroid name={color} style={{flex: 1}}>
-              <View style={{backgroundColor: color, flex: 1}} />
-            </SharedElementAndroid>
-          </TouchableHighlight>
-        ))}
-        {children}
-      </View>
+      <ScrollView
+        style={styles.scene}
+        contentInsetAdjustmentBehavior="automatic">
+        <View style={styles.colors}>
+          {colors.map(color => (
+            <TouchableHighlight
+              key={color}
+              style={styles.color}
+              underlayColor={color}                
+              onPress={() => {
+                stateNavigator.navigate('detail', {color});
+              }}>
+              <SharedElementAndroid name={color} style={{flex: 1}}>
+                <View style={{backgroundColor: color, flex: 1}} />
+              </SharedElementAndroid>
+            </TouchableHighlight>
+          ))}
+          {children}
+        </View>
+      </ScrollView>
     )}
   </NavigationContext.Consumer>
 );
@@ -51,11 +55,7 @@ export default class Grid extends React.Component {
             autoCapitalize="none"
             obscureBackground={false}
             onChangeText={text => this.setState({text})}>
-            <ScrollView
-              style={styles.scene}
-              contentInsetAdjustmentBehavior="automatic">
-              <Colors colors={matchedColors} />
-            </ScrollView>
+            <Colors colors={matchedColors} />
           </SearchBarIOS>
         </NavigationBar>
         <Colors colors={colors} />

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {StyleSheet, ScrollView, View, TouchableHighlight} from 'react-native';
+import {StyleSheet, Platform, ScrollView, View, TouchableHighlight} from 'react-native';
 import {NavigationContext} from 'navigation-react';
 import {SharedElementAndroid, NavigationBar, SearchBarIOS} from 'navigation-react-native';
 
@@ -30,6 +30,10 @@ const Colors = ({colors, children}) => (
   </NavigationContext.Consumer>
 );
 
+const Container = (props) => (
+  Platform.OS === 'ios' ? <ScrollView {...props}/> : <>{props.children}</>
+);
+
 export default class Grid extends React.Component {
   constructor(props) {
     super(props);
@@ -42,7 +46,9 @@ export default class Grid extends React.Component {
       color.indexOf(text.toLowerCase()) !== -1
     ));
     return (
-      <>
+      <Container
+        style={styles.scene}
+        contentInsetAdjustmentBehavior="automatic">
         <NavigationBar largeTitle={true} title="Colors">
           <SearchBarIOS
             text={text}
@@ -53,7 +59,7 @@ export default class Grid extends React.Component {
           </SearchBarIOS>
         </NavigationBar>
         <Colors colors={colors} />
-      </>
+      </Container>
     );
   }
 }

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -6,26 +6,22 @@ import {SharedElementAndroid, NavigationBar, SearchBarIOS} from 'navigation-reac
 const Colors = ({colors, children}) => (
   <NavigationContext.Consumer>
     {({stateNavigator}) => (
-      <ScrollView
-        style={styles.scene}
-        contentInsetAdjustmentBehavior="automatic">
-        <View style={styles.colors}>
-          {colors.map(color => (
-            <TouchableHighlight
-              key={color}
-              style={styles.color}
-              underlayColor={color}                
-              onPress={() => {
-                stateNavigator.navigate('detail', {color});
-              }}>
-              <SharedElementAndroid name={color} style={{flex: 1}}>
-                <View style={{backgroundColor: color, flex: 1}} />
-              </SharedElementAndroid>
-            </TouchableHighlight>
-          ))}
-          {children}
-        </View>
-      </ScrollView>
+      <View style={styles.colors}>
+        {colors.map(color => (
+          <TouchableHighlight
+            key={color}
+            style={styles.color}
+            underlayColor={color}                
+            onPress={() => {
+              stateNavigator.navigate('detail', {color});
+            }}>
+            <SharedElementAndroid name={color} style={{flex: 1}}>
+              <View style={{backgroundColor: color, flex: 1}} />
+            </SharedElementAndroid>
+          </TouchableHighlight>
+        ))}
+        {children}
+      </View>
     )}
   </NavigationContext.Consumer>
 );
@@ -55,7 +51,11 @@ export default class Grid extends React.Component {
             autoCapitalize="none"
             obscureBackground={false}
             onChangeText={text => this.setState({text})}>
-            <Colors colors={matchedColors} />
+            <ScrollView
+              style={styles.scene}
+              contentInsetAdjustmentBehavior="automatic">
+              <Colors colors={matchedColors} />
+            </ScrollView>
           </SearchBarIOS>
         </NavigationBar>
         <Colors colors={colors} />


### PR DESCRIPTION
Before you merge this PR, have a look at the current behaviour on iOS**. There are two problems:
1. The navigation bar on the grid scene is completely transparent. Scroll the colors and watch how they show through completely
2. Click the search and click cancel twice and see that the content doesn't scroll up properly the second time

I wrapped the content in a `ScrollView` on iOS to fix these issues. It seems to be a problem only when `largeTitles` is true so we don't need the same fix on the details screen. Only did this on iOS because it makes the whole screen scroll on Android,

Please merge if you're happy with the fixes
