### PR TITLE
Removed Title Centering on Android

### DIFF
--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {StyleSheet, ScrollView, Text, View, TouchableHighlight} from 'react-native';
+import {Platform, StyleSheet, ScrollView, Text, View, TouchableHighlight} from 'react-native';
 import {NavigationContext} from 'navigation-react';
 import {NavigationBar, RightBar, BarButton, TitleBar, SharedElementAndroid} from 'navigation-react-native';
 
@@ -7,10 +7,12 @@ export default ({colors, color}) => (
   <NavigationContext.Consumer>
     {({stateNavigator}) => (
       <>
-        <NavigationBar title="Color">
+        <NavigationBar
+          title="Color"
+          barTintColor={Platform.OS === 'android' ? '#fff' : null}>
           <TitleBar style={styles.titleBar}>
             <Text style={styles.titleBarText}>Color</Text>
-            <View style={{backgroundColor: color, width: 28, height: 28}}/>              
+            <View style={{backgroundColor: color, width: 28, height: 28}}/>
           </TitleBar>
           <RightBar>
             <BarButton title="X" show="always" systemItem="cancel" onPress={() => {
@@ -51,12 +53,11 @@ const styles = StyleSheet.create({
   titleBar: {
     flex: 1,
     flexDirection: 'row',
-    justifyContent: 'center',
     alignItems: 'center'
   },
   titleBarText: {
     marginRight: 4,
-    fontSize: 16
+    fontSize: Platform.OS === 'ios' ? 16 : 20,
   },
   back: {
     fontSize: 20,

--- a/NavigationReactNative/sample/zoom/Detail.js
+++ b/NavigationReactNative/sample/zoom/Detail.js
@@ -15,7 +15,7 @@ export default ({colors, color}) => (
             <View style={{backgroundColor: color, width: 28, height: 28}}/>
           </TitleBar>
           <RightBar>
-            <BarButton title="X" show="always" systemItem="cancel" onPress={() => {
+            <BarButton title="cancel" show="always" systemItem="cancel" onPress={() => {
               stateNavigator.navigateBack(1);
             }} />
           </RightBar>

--- a/NavigationReactNative/sample/zoom/Grid.js
+++ b/NavigationReactNative/sample/zoom/Grid.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {StyleSheet, Platform, ScrollView, View, TouchableHighlight} from 'react-native';
+import {Platform, StyleSheet, ScrollView, View, TouchableHighlight} from 'react-native';
 import {NavigationContext} from 'navigation-react';
 import {SharedElementAndroid, NavigationBar, SearchBarIOS} from 'navigation-react-native';
 
@@ -49,7 +49,10 @@ export default class Grid extends React.Component {
       <Container
         style={styles.scene}
         contentInsetAdjustmentBehavior="automatic">
-        <NavigationBar largeTitle={true} title="Colors">
+        <NavigationBar
+          largeTitle={true}
+          title="Colors"
+          barTintColor={Platform.OS === 'android' ? '#fff' : null}>
           <SearchBarIOS
             text={text}
             autoCapitalize="none"

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationBarManager.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationBarManager.java
@@ -49,13 +49,11 @@ public class NavigationBarManager extends ViewGroupManager<NavigationBarView> {
                 Toolbar.LayoutParams.MATCH_PARENT
         );
         parent.toolbar.addView(child, index, layoutParams);
-        parent.toolbar.setContentInsetsRelative(0, 0);
     }
 
     @Override
     public void removeViewAt(NavigationBarView parent, int index) {
         parent.toolbar.removeViewAt(index);
-        parent.toolbar.setContentInsetsRelative(parent.defaultContentInsetStart, parent.defaultContentInsetEnd);
     }
 
     @ReactProp(name = "title")

--- a/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationBarView.java
+++ b/NavigationReactNative/src/android/app/src/main/java/com/navigation/reactnative/NavigationBarView.java
@@ -48,8 +48,6 @@ public class NavigationBarView extends AppBarLayout {
 
     Toolbar toolbar;
 
-    int defaultContentInsetStart;
-    int defaultContentInsetEnd;
     int defaultTitleTextColor;
     ViewOutlineProvider defaultOutlineProvider;
     Drawable defaultBackground;
@@ -71,8 +69,6 @@ public class NavigationBarView extends AppBarLayout {
         toolbar = new Toolbar(context);
         addView(toolbar, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
 
-        defaultContentInsetStart = toolbar.getContentInsetStart();
-        defaultContentInsetEnd = toolbar.getContentInsetEnd();
         defaultTitleTextColor = getDefaultTitleTextColor();
         defaultOverflowIcon = toolbar.getOverflowIcon();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {


### PR DESCRIPTION
Centering the title is an iOS thing. We shouldn't copy this over to Android. I removed the content inset logic because this was all about centering the title. Also, it didn't work when there was a logo or navigation image - which is 99% of the time. I updated the zoom sample so that the title is left aligned on the Details page. (I kept the title centered on iOS)